### PR TITLE
Update fluentd-daemonset.yaml

### DIFF
--- a/ch08/ch08_1_5/fluentd-daemonset.yaml
+++ b/ch08/ch08_1_5/fluentd-daemonset.yaml
@@ -31,6 +31,8 @@ spec:
             value: "9200"
           - name: FLUENT_ELASTICSEARCH_SCHEME
             value: "http"
+          - name: FLUENT_UID
+            value: "0"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
발생했던 문제 : 해당 예제소스로 돌릴경우 데몬셋 파드의 Crash가 발생
문제 해결 : 로그를 보니 권한문제라 하여 환경변수에 다음 두줄을 추가함.
          - name: FLUENT_UID
            value: "0"
실습환경: win10/ minikube 활용

확인부탁드립니다.
